### PR TITLE
Fix CPU Information rewind ordering

### DIFF
--- a/src/BinaryMapper.Windows.Minidump/Structures/CPU_INFORMATION.cs
+++ b/src/BinaryMapper.Windows.Minidump/Structures/CPU_INFORMATION.cs
@@ -4,17 +4,18 @@ namespace BinaryMapper.Windows.Minidump.Structures
 {
     /// <summary>
     /// https://msdn.microsoft.com/en-us/library/ms680396.aspx
+    /// Note the order is switched to the C definition, because for our [Rewind] attribute, we need the smaller structure to come first
     /// </summary>
     public sealed class CPU_INFORMATION
     {
         /// <summary>
-        /// The CPU information obtained from the CPUID instruction. This structure is supported only for x86 computers.
-        /// </summary>
-        [Rewind]
-        public CPU_INFORMATION_X86_CPUINFO X86CpuInfo;
-        /// <summary>
         /// Other CPU information. This structure is supported only for non-x86 computers.
         /// </summary>
+        [Rewind]
         public CPU_INFORMATION_OTHER_CPUINFO OtherCpuInfo;
+        /// <summary>
+        /// The CPU information obtained from the CPUID instruction. This structure is supported only for x86 computers.
+        /// </summary>
+        public CPU_INFORMATION_X86_CPUINFO X86CpuInfo;
     }
 }


### PR DESCRIPTION
The structures here have different sizes.
CPU_INFORMATION_X86_CPUINFO is 24 bytes
CPU_INFORMATION_OTHER_CPUINFO is 16 bytes.


The old ordering was:
- Read 24 bytes
- Rewind 24 bytes
- Read 16 bytes

After this, our stream offset would be 16. But the CPU_INFORMATION structure should be 24 bytes long.
If there is another structure after this, we would be reading at wrong position.


The new ordering is:
- Read 16 bytes
- Rewind 16 bytes
- Read 24 bytes

Now our stream offset is 24, and another structure after it will be read correctly.


This does not matter in the current read-only implementation. Luckily there is no structure after this.
But when writing this matters, because when writing MINIDUMP_SYSTEM_INFO_STREAM the size of the directory entry must be 0x38, but because we are 8 bytes off, it will be 0x30. And a written dump will be refused by WinDbg/VisualStudio.