### PR TITLE
Fix incorrect size for MINIDUMP_EXCEPTION

### DIFF
--- a/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_EXCEPTION.cs
+++ b/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_EXCEPTION.cs
@@ -15,7 +15,7 @@ namespace BinaryMapper.Windows.Minidump.Structures
         public ULONG64 ExceptionAddress;
         public ULONG32 NumberParameters;
         public ULONG32 __unusedAlignment;
-        [ArraySize(nameof(NumberParameters))]
+        [ArraySize(15)]
         public ULONG64[] ExceptionInformation;
     }
 


### PR DESCRIPTION
https://learn.microsoft.com/de-de/windows/win32/api/minidumpapiset/ns-minidumpapiset-minidump_exception

The ExceptionInformation array should have length of EXCEPTION_MAXIMUM_PARAMETERS

This makes the reader fail to read the ThreadContext

Before:
![devenv_2024-07-29_17-54-08](https://github.com/user-attachments/assets/4a7087b9-74c6-4833-8301-d6a95151328f)
After:
![devenv_2024-07-29_17-54-57](https://github.com/user-attachments/assets/a595cfdf-6f00-4c81-b174-1b4a1ab38cec)
