### PR TITLE
Add Minidump writing support

### DIFF
--- a/BinaryMapper.sln
+++ b/BinaryMapper.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27428.2027
@@ -24,29 +24,51 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DBDF4F0C-B771-49FB-9F05-31BA1908A9EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DBDF4F0C-B771-49FB-9F05-31BA1908A9EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBDF4F0C-B771-49FB-9F05-31BA1908A9EA}.Debug|x64.ActiveCfg = Debug|x64
+		{DBDF4F0C-B771-49FB-9F05-31BA1908A9EA}.Debug|x64.Build.0 = Debug|x64
 		{DBDF4F0C-B771-49FB-9F05-31BA1908A9EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DBDF4F0C-B771-49FB-9F05-31BA1908A9EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBDF4F0C-B771-49FB-9F05-31BA1908A9EA}.Release|x64.ActiveCfg = Release|x64
+		{DBDF4F0C-B771-49FB-9F05-31BA1908A9EA}.Release|x64.Build.0 = Release|x64
 		{E1F35017-D4EA-4587-B6E5-4825331BC5C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E1F35017-D4EA-4587-B6E5-4825331BC5C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1F35017-D4EA-4587-B6E5-4825331BC5C7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E1F35017-D4EA-4587-B6E5-4825331BC5C7}.Debug|x64.Build.0 = Debug|Any CPU
 		{E1F35017-D4EA-4587-B6E5-4825331BC5C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1F35017-D4EA-4587-B6E5-4825331BC5C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1F35017-D4EA-4587-B6E5-4825331BC5C7}.Release|x64.ActiveCfg = Release|Any CPU
+		{E1F35017-D4EA-4587-B6E5-4825331BC5C7}.Release|x64.Build.0 = Release|Any CPU
 		{B4A9A36E-27B1-45E4-86E7-967DAE95846C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4A9A36E-27B1-45E4-86E7-967DAE95846C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4A9A36E-27B1-45E4-86E7-967DAE95846C}.Debug|x64.ActiveCfg = Debug|x64
+		{B4A9A36E-27B1-45E4-86E7-967DAE95846C}.Debug|x64.Build.0 = Debug|x64
 		{B4A9A36E-27B1-45E4-86E7-967DAE95846C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B4A9A36E-27B1-45E4-86E7-967DAE95846C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4A9A36E-27B1-45E4-86E7-967DAE95846C}.Release|x64.ActiveCfg = Release|x64
+		{B4A9A36E-27B1-45E4-86E7-967DAE95846C}.Release|x64.Build.0 = Release|x64
 		{C2FC24D8-2BBB-49DA-8B09-F0DCC8228C6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C2FC24D8-2BBB-49DA-8B09-F0DCC8228C6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2FC24D8-2BBB-49DA-8B09-F0DCC8228C6F}.Debug|x64.ActiveCfg = Debug|x64
+		{C2FC24D8-2BBB-49DA-8B09-F0DCC8228C6F}.Debug|x64.Build.0 = Debug|x64
 		{C2FC24D8-2BBB-49DA-8B09-F0DCC8228C6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C2FC24D8-2BBB-49DA-8B09-F0DCC8228C6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2FC24D8-2BBB-49DA-8B09-F0DCC8228C6F}.Release|x64.ActiveCfg = Release|x64
+		{C2FC24D8-2BBB-49DA-8B09-F0DCC8228C6F}.Release|x64.Build.0 = Release|x64
 		{97A526CA-F3D1-4AB0-A65B-F41B84EC9B4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{97A526CA-F3D1-4AB0-A65B-F41B84EC9B4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97A526CA-F3D1-4AB0-A65B-F41B84EC9B4B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{97A526CA-F3D1-4AB0-A65B-F41B84EC9B4B}.Debug|x64.Build.0 = Debug|Any CPU
 		{97A526CA-F3D1-4AB0-A65B-F41B84EC9B4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97A526CA-F3D1-4AB0-A65B-F41B84EC9B4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97A526CA-F3D1-4AB0-A65B-F41B84EC9B4B}.Release|x64.ActiveCfg = Release|Any CPU
+		{97A526CA-F3D1-4AB0-A65B-F41B84EC9B4B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BinaryMapper.Core/Attributes/FixupAttribute.cs
+++ b/src/BinaryMapper.Core/Attributes/FixupAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BinaryMapper.Core.Attributes
+{
+    /// <summary>
+    /// Marks values that need to be fixed-up. Their value is only known after other data after it, is written
+    /// </summary>
+    public class FixupAttribute : Attribute
+    {
+    }
+}

--- a/src/BinaryMapper.Core/BinaryMapper.Core.csproj
+++ b/src/BinaryMapper.Core/BinaryMapper.Core.csproj
@@ -10,6 +10,7 @@
     <PackageTags>parsing;structures;binary;reading;formats</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/alanedwardes/BinaryMapper/master/logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/alanedwardes/BinaryMapper</PackageProjectUrl>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
 </Project>

--- a/src/BinaryMapper.Core/IStreamBinaryMapper.cs
+++ b/src/BinaryMapper.Core/IStreamBinaryMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace BinaryMapper.Core
@@ -11,5 +12,9 @@ namespace BinaryMapper.Core
         TObject ReadObject<TObject>(Stream stream);
         object ReadValue(Stream stream, Type type);
         TValue ReadValue<TValue>(Stream stream);
+
+        void WriteArray(Stream stream, uint length, Type type, Array objects);
+        void WriteValue(Stream stream, Type type, object value);
+        List<(Type, long)> WriteObject(Stream stream, Type type, object structure);
     }
 }

--- a/src/BinaryMapper.Core/PrimitiveExtensions.cs
+++ b/src/BinaryMapper.Core/PrimitiveExtensions.cs
@@ -119,5 +119,61 @@ namespace BinaryMapper.Core
                 throw new NotImplementedException();
             }
         }
+
+        public static byte[] ObjectToBytes(this Type type, object o)
+        {
+            if (type == typeof(SByte))
+            {
+                return new byte[] { (byte)o };
+            }
+            else if (type == typeof(Byte))
+            {
+                return new byte[] { (byte)o };
+            }
+            else if (type == typeof(Int16))
+            {
+                return BitConverter.GetBytes((Int16)o);
+            }
+            else if (type == typeof(UInt16))
+            {
+                return BitConverter.GetBytes((UInt16)o);
+            }
+            else if (type == typeof(Int32))
+            {
+                return BitConverter.GetBytes((Int32)o);
+            }
+            else if (type == typeof(UInt32))
+            {
+                return BitConverter.GetBytes((UInt32)o);
+            }
+            else if (type == typeof(Int64))
+            {
+                return BitConverter.GetBytes((Int64)o);
+            }
+            else if (type == typeof(UInt64))
+            {
+                return BitConverter.GetBytes((UInt64)o);
+            }
+            else if (type == typeof(Char))
+            {
+                return BitConverter.GetBytes((Char)o);
+            }
+            else if (type == typeof(Single))
+            {
+                return BitConverter.GetBytes((Single)o);
+            }
+            else if (type == typeof(Double))
+            {
+                return BitConverter.GetBytes((Double)o);
+            }
+            else if (type == typeof(Boolean))
+            {
+                return BitConverter.GetBytes((Boolean)o);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }

--- a/src/BinaryMapper.Core/StreamBinaryMapper.cs
+++ b/src/BinaryMapper.Core/StreamBinaryMapper.cs
@@ -1,6 +1,8 @@
 ﻿using BinaryMapper.Core.Attributes;
 using BinaryMapper.Core.Enums;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -45,7 +47,7 @@ namespace BinaryMapper.Core
 
         public object ReadObject(Stream stream, Type type)
         {
-            var fields = type.GetFields(TypeRetrievalFlags);
+            var fields = type.GetFields(TypeRetrievalFlags).Where(x => x.GetCustomAttribute<NonSerializedAttribute>() == null);
 
             object structure = Activator.CreateInstance(type);
 
@@ -133,5 +135,207 @@ namespace BinaryMapper.Core
 
             return structure;
         }
+
+
+
+
+        public void WriteArray(Stream stream, uint length, Type type, Array objects)
+        {
+            foreach (var o in objects)
+            {
+                if (type.IsPrimitive || type.IsEnum)
+                    WriteValue(stream, type, o);
+                else
+                {
+                    var rvaList = WriteObject(stream, type, o);
+                    Debug.Assert(rvaList.Count == 0); // We don't support that, we would need to forward them
+                }
+            }
+        }
+
+        public void WriteValue(Stream stream, Type type, object value)
+        {
+            var unwrapped = type.IsEnum ? Enum.GetUnderlyingType(type) : type;
+            var primitiveSize = unwrapped.SizeOfPrimitiveType();
+
+            var data = unwrapped.ObjectToBytes(value);
+            Debug.Assert(data.Length == primitiveSize);
+            stream.Write(data, 0, data.Length);
+        }
+
+        //! Returns list of all RVA pointers
+        public List<(Type, long)> WriteObject(Stream stream, Type type, object structure)
+        {
+            List<(Type, long)> rvaList = new List<(Type, long)>();
+            var fields = type.GetFields(TypeRetrievalFlags).Where(x => x.GetCustomAttribute<NonSerializedAttribute>() == null).ToArray();
+
+            // We need to iterate twice, first set lengths, and then write data (Otherwise we would only set the length when we get to the data element, after the length was already written)
+
+            foreach (var field in fields)
+            {
+                if (field.FieldType == typeof(string))
+                {
+                    var characterArrayAttribute = field.GetCustomAttribute<CharacterArrayAttribute>(true);
+                    if (characterArrayAttribute == null)
+                    {
+                        throw new InvalidOperationException($"Required string attribute CharacterArrayAttribute not set on property {field.Name}");
+                    }
+
+                    var stringValue = (string)field.GetValue(structure);
+
+                    Encoding encoding;
+                    switch (characterArrayAttribute.CharacterType)
+                    {
+                        case CharacterType.WCHAR:
+                            encoding = Encoding.Unicode;
+                            break;
+                        case CharacterType.CHAR:
+                            encoding = Encoding.UTF8;
+                            break;
+                        default:
+                            throw new NotImplementedException($"Character type {characterArrayAttribute.CharacterType} not implemented.");
+                    }
+
+                    var dataWriteBytes = encoding.GetBytes(stringValue);
+
+                    if (!string.IsNullOrWhiteSpace(characterArrayAttribute.PropertyName))
+                    {
+                        var arrayNumberField = type.GetField(characterArrayAttribute.PropertyName, TypeRetrievalFlags);
+                        if (arrayNumberField == null)
+                        {
+                            throw new InvalidOperationException($"Referenced string size property {characterArrayAttribute.PropertyName} not found");
+                        }
+
+                        arrayNumberField.SetValue(structure, Convert.ChangeType(dataWriteBytes.Length, arrayNumberField.FieldType));
+                    }
+                }
+                else if (field.FieldType.IsArray)
+                {
+                    var sizeAttribute = field.GetCustomAttribute<ArraySizeAttribute>(true);
+                    if (sizeAttribute == null)
+                    {
+                        throw new InvalidOperationException($"Required array attribute ArraySizeAttribute not set on property {field.Name}");
+                    }
+
+                    var arrayValue = (Array)field.GetValue(structure);
+
+                    if (!string.IsNullOrWhiteSpace(sizeAttribute.PropertyName))
+                    {
+                        var arrayNumberField = type.GetField(sizeAttribute.PropertyName, TypeRetrievalFlags);
+                        if (arrayNumberField == null)
+                        {
+                            throw new InvalidOperationException($"Referenced array size property {sizeAttribute.PropertyName} not found");
+                        }
+
+                        arrayNumberField.SetValue(structure, Convert.ChangeType(arrayValue.Length, arrayNumberField.FieldType));
+                    }
+                }
+            }
+            
+            foreach (var field in fields)
+            {
+                if (field.GetCustomAttribute<NonSerializedAttribute>() != null)
+                    continue;
+
+                var positionBeforeWriting = stream.Position;
+
+                if (field.FieldType.IsPrimitive || field.FieldType.IsEnum)
+                {
+                    WriteValue(stream, field.FieldType, field.GetValue(structure));
+                }
+                else if (field.FieldType == typeof(string))
+                {
+                    var characterArrayAttribute = field.GetCustomAttribute<CharacterArrayAttribute>(true);
+                    if (characterArrayAttribute == null)
+                    {
+                        throw new InvalidOperationException($"Required string attribute CharacterArrayAttribute not set on property {field.Name}");
+                    }
+
+                    var stringValue = (string)field.GetValue(structure);
+
+                    Encoding encoding;
+                    byte[] nullChar;
+                    switch (characterArrayAttribute.CharacterType)
+                    {
+                        case CharacterType.WCHAR:
+                            encoding = Encoding.Unicode;
+                            nullChar = new byte[] {0, 0};
+                            break;
+                        case CharacterType.CHAR:
+                            encoding = Encoding.UTF8;
+                            nullChar = new byte[] {0};
+                            break;
+                        default:
+                            throw new NotImplementedException($"Character type {characterArrayAttribute.CharacterType} not implemented.");
+                    }
+
+                    var dataWriteBytes = encoding.GetBytes(stringValue);
+
+
+                    var stringLength = characterArrayAttribute.ConstantLength;
+                    if (!string.IsNullOrWhiteSpace(characterArrayAttribute.PropertyName))
+                    {
+                        // We have set the value in first fields iteration
+                        stringLength = dataWriteBytes.Length;
+                    }
+
+
+
+                    stream.Write(dataWriteBytes, 0, dataWriteBytes.Length);
+                    if (dataWriteBytes.Length < stringLength) // Somehow the string we have is shorter than what we should be writing (constant length string and our input is too short
+                    {
+                        Debug.Assert(characterArrayAttribute.TrimNullTerminator); // This should only happen if we expect null chars
+                        // Fill up rest with null chars
+
+                        for (int i = dataWriteBytes.Length; i < stringLength; i++)
+                            stream.Write(nullChar, 0, nullChar.Length);
+                    }
+                    else if (!string.IsNullOrWhiteSpace(characterArrayAttribute.PropertyName)) // Not for static lengths
+                    {
+                        stream.Write(nullChar, 0, nullChar.Length); // Strings seem to always have null terminator, even though we provide the length. And the null terminator is also not included in length. This is unexpected, but WinDbg breaks without doing this
+                    }
+                }
+                else if (field.FieldType.IsArray)
+                {
+                    var sizeAttribute = field.GetCustomAttribute<ArraySizeAttribute>(true);
+                    if (sizeAttribute == null)
+                    {
+                        throw new InvalidOperationException($"Required array attribute ArraySizeAttribute not set on property {field.Name}");
+                    }
+
+                    var arrayValue = (Array) field.GetValue(structure);
+
+
+                    var arrayLength = sizeAttribute.ConstantSize;
+                    if (!string.IsNullOrWhiteSpace(sizeAttribute.PropertyName))
+                    {
+                        // We have set the value in first fields iteration
+                        arrayLength = (uint)arrayValue.Length;
+                    }
+
+                    WriteArray(stream, arrayLength, field.FieldType.GetElementType(), arrayValue);
+                    //field.SetValue(structure, WriteArray(stream, arrayLength, field.FieldType.GetElementType()));
+                }
+                else
+                {
+                    rvaList.AddRange(WriteObject(stream, field.FieldType, field.GetValue(structure)));
+                }
+
+                var rvaAttrib = field.GetCustomAttribute<FixupAttribute>(true);
+                if (rvaAttrib != null)
+                {
+                    rvaList.Add((field.FieldType, positionBeforeWriting));
+                }
+
+                // This attribute is for dealing with unions
+                if (field.GetCustomAttribute<RewindAttribute>() != null)
+                {
+                    stream.Position = positionBeforeWriting;
+                }
+            }
+
+            return rvaList;
+        }
+
     }
 }

--- a/src/BinaryMapper.Windows.Executable/BinaryMapper.Windows.Executable.csproj
+++ b/src/BinaryMapper.Windows.Executable/BinaryMapper.Windows.Executable.csproj
@@ -10,6 +10,7 @@
     <PackageTags>parsing;minidump;binary;reading;memorydump;debugging</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/alanedwardes/BinaryMapper/master/logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/alanedwardes/BinaryMapper</PackageProjectUrl>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BinaryMapper.Windows.Minidump/BinaryMapper.Windows.Minidump.csproj
+++ b/src/BinaryMapper.Windows.Minidump/BinaryMapper.Windows.Minidump.csproj
@@ -10,6 +10,7 @@
     <PackageTags>parsing;binary;reading;executable;dos;pe</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/alanedwardes/BinaryMapper/master/logo.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/alanedwardes/BinaryMapper</PackageProjectUrl>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BinaryMapper.Windows.Minidump/MinidumpMapper.cs
+++ b/src/BinaryMapper.Windows.Minidump/MinidumpMapper.cs
@@ -2,6 +2,7 @@
 using BinaryMapper.Windows.Minidump.Structures;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 
@@ -39,6 +40,38 @@ namespace BinaryMapper.Windows.Minidump
                 {
                     case MINIDUMP_STREAM_TYPE.ThreadListStream:
                         minidump.ThreadListStream = _streamBinaryMapper.ReadObject<MINIDUMP_THREAD_LIST_STREAM>(stream);
+
+                        // Fill referenced data
+                        foreach (var minidumpThread in minidump.ThreadListStream.Threads)
+                        {
+                            if (minidumpThread.ThreadContext.DataSize != 0)
+                            {
+                                var descr = minidumpThread.ThreadContext;
+                                stream.Position = descr.Rva;
+                                var buffer = new byte[descr.DataSize];
+                                stream.Read(buffer, 0, buffer.Length);
+                                minidumpThread.ThreadContext = new MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA()
+                                {
+                                    Rva = descr.Rva,
+                                    DataSize = descr.DataSize,
+                                    MemoryData = buffer
+                                };
+                            }
+
+                            if (minidumpThread.Stack.Memory.DataSize != 0)
+                            {
+                                var descr = minidumpThread.Stack.Memory;
+                                stream.Position = descr.Rva;
+                                var buffer = new byte[descr.DataSize];
+                                stream.Read(buffer, 0, buffer.Length);
+                                minidumpThread.Stack.Memory = new MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA()
+                                {
+                                    Rva = descr.Rva,
+                                    DataSize = descr.DataSize,
+                                    MemoryData = buffer
+                                };
+                            }
+                        }
                         break;
                     case MINIDUMP_STREAM_TYPE.ModuleListStream:
                         minidump.ModuleListStream = _streamBinaryMapper.ReadObject<MINIDUMP_MODULE_LIST_STREAM>(stream);
@@ -51,9 +84,41 @@ namespace BinaryMapper.Windows.Minidump
                         break;
                     case MINIDUMP_STREAM_TYPE.MemoryListStream:
                         minidump.MemoryListStream = _streamBinaryMapper.ReadObject<MINIDUMP_MEMORY_LIST_STREAM>(stream);
+
+                        // Fill referenced data
+                        foreach (var memRange in minidump.MemoryListStream.MemoryRanges)
+                        {
+                            if (memRange.Memory.DataSize != 0)
+                            {
+                                var descr = memRange.Memory;
+                                stream.Position = descr.Rva;
+                                var buffer = new byte[descr.DataSize];
+                                stream.Read(buffer, 0, buffer.Length);
+                                memRange.Memory = new MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA()
+                                {
+                                    Rva = descr.Rva,
+                                    DataSize = descr.DataSize,
+                                    MemoryData = buffer
+                                };
+                            }
+                        }
+
                         break;
                     case MINIDUMP_STREAM_TYPE.ExceptionStream:
                         minidump.ExceptionStream = _streamBinaryMapper.ReadObject<MINIDUMP_EXCEPTION_STREAM>(stream);
+                        if (minidump.ExceptionStream.ThreadContext.DataSize != 0)
+                        {
+                            var descr = minidump.ExceptionStream.ThreadContext;
+                            stream.Position = descr.Rva;
+                            var buffer = new byte[descr.DataSize];
+                            stream.Read(buffer, 0, buffer.Length);
+                            minidump.ExceptionStream.ThreadContext = new MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA()
+                            {
+                                Rva = descr.Rva,
+                                DataSize = descr.DataSize,
+                                MemoryData = buffer
+                            };
+                        }
                         break;
                     case MINIDUMP_STREAM_TYPE.SystemInfoStream:
                         minidump.SystemInfoStream = _streamBinaryMapper.ReadObject<MINIDUMP_SYSTEM_INFO_STREAM>(stream);
@@ -183,5 +248,179 @@ namespace BinaryMapper.Windows.Minidump
             }
             return ret;
         }
+
+
+        private void WriteFixup(Stream stream, (Type, long) fixup, object data)
+        {
+            var oldPos = stream.Position;
+            stream.Position = fixup.Item2;
+            _streamBinaryMapper.WriteValue(stream, fixup.Item1, data);
+            stream.Position = oldPos;
+        }
+        private void WriteDirectoryObject(Stream stream, List<MINIDUMP_DIRECTORY> directory, object data, MINIDUMP_STREAM_TYPE type)
+        {
+            if (data == null) return;
+
+            var writePos = stream.Position;
+            _streamBinaryMapper.WriteObject(stream, data.GetType(), data);
+
+            directory.Add(new MINIDUMP_DIRECTORY
+            {
+                StreamType = type,
+                Location = new MINIDUMP_LOCATION_DESCRIPTOR
+                {
+                    Rva = (uint)writePos,
+                    DataSize = (uint)(stream.Position - writePos)
+                }
+            });
+        }
+
+        public void WriteMinidump(Stream stream, Minidump dump)
+        {
+            //#TODO clear the mapper, otherwise cannot call WriteMinidump multiple times with same mapper because it keeps map of RVA's
+
+            dump.Header.Signature = "MDMP";
+            //dump.Header.Flags = (MINIDUMP_TYPE)0x0000000000200041; //#TODO ??
+            dump.Header.Flags = MINIDUMP_TYPE.MiniDumpWithDataSegs | MINIDUMP_TYPE.MiniDumpWithIndirectlyReferencedMemory; //#TODO ??
+            dump.Header.CheckSum = 0;
+            dump.Header.Version = 0xa07ca793; // Hardcoded MINIDUMP_VERSION, I got this from reading a mdmp created by DbgHelp
+            dump.Header.TimeDateStamp = (uint)DateTimeOffset.Now.ToUnixTimeSeconds();
+
+            // We fix StreamDirectoryRva/NumberOfStreams later
+            var headerFixups = _streamBinaryMapper.WriteObject(stream, typeof(MINIDUMP_HEADER), dump.Header);
+            
+            // It is quite annoying, but the directory really needs to be at the top. (WinDbg will refuse to read RVA's when they are before the directory)
+            List<MINIDUMP_DIRECTORY> directory = new List<MINIDUMP_DIRECTORY>();
+            // We need to write the correct number of elements. Currently its just placeholders, we will write it again properly later
+            for (int i = 0; i < 5; i++)
+                directory.Add(new MINIDUMP_DIRECTORY(){Location = new MINIDUMP_LOCATION_DESCRIPTOR()});
+
+            dump.Header.StreamDirectoryRva = (uint)stream.Position;
+            dump.Header.NumberOfStreams = (uint)directory.Count;
+            _streamBinaryMapper.WriteArray(stream, dump.Header.NumberOfStreams, typeof(MINIDUMP_DIRECTORY), directory.ToArray());
+
+            // headerFixups
+            WriteFixup(stream, headerFixups[0], dump.Header.NumberOfStreams);
+            WriteFixup(stream, headerFixups[1], dump.Header.StreamDirectoryRva);
+
+            directory.Clear(); // We will re-add the elements with proper data now
+
+            // Write all streams
+            {
+                {
+                    // Write referenced memory RVA's
+                    foreach (var minidumpThread in dump.ThreadListStream.Threads)
+                    {
+                        {
+                            if (minidumpThread.ThreadContext is MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA data)
+                            {
+                                var writePos = stream.Position;
+                                stream.Write(data.MemoryData, 0, data.MemoryData.Length);
+                                data.Rva = (uint)writePos;
+                                data.DataSize = (uint)data.MemoryData.Length;
+                            }
+                        }
+                        {
+                            if (minidumpThread.Stack.Memory is MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA data)
+                            {
+                                var writePos = stream.Position;
+                                stream.Write(data.MemoryData, 0, data.MemoryData.Length);
+                                data.Rva = (uint)writePos;
+                                data.DataSize = (uint)data.MemoryData.Length;
+                            }
+                        }
+                    }
+
+                    WriteDirectoryObject(stream, directory, dump.ThreadListStream, MINIDUMP_STREAM_TYPE.ThreadListStream);
+                }
+                
+
+                // Not enabled because I don't know the sizes, and my test dumps didn't have this.
+                //if (dump.ThreadInfoListStream != null)
+                //{
+                //    var writePos = stream.Position;
+                //
+                //
+                //    dump.ThreadInfoListStream.SizeOfHeader = 5; //#TODO don't hardcode? Or atleast not magic numbers
+                //    dump.ThreadInfoListStream.SizeOfEntry = 5;
+                //    _streamBinaryMapper.WriteObject(stream, typeof(MINIDUMP_THREAD_INFO_LIST_STREAM), dump.ThreadInfoListStream);
+                //
+                //    directory.Add(new MINIDUMP_DIRECTORY
+                //    {
+                //        StreamType = MINIDUMP_STREAM_TYPE.ThreadInfoListStream,
+                //        Location = new MINIDUMP_LOCATION_DESCRIPTOR
+                //        {
+                //            Rva = (uint)writePos,
+                //            DataSize = (uint)(stream.Position - writePos)
+                //        }
+                //    });
+                //}
+
+                {
+                    var writePos = stream.Position;
+                    if (dump.ExceptionStream.ThreadContext is MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA data)
+                    {
+                        stream.Write(data.MemoryData, 0, data.MemoryData.Length);
+                        data.Rva = (uint)writePos;
+                        data.DataSize = (uint)data.MemoryData.Length;
+                    }
+
+                    WriteDirectoryObject(stream, directory, dump.ExceptionStream, MINIDUMP_STREAM_TYPE.ExceptionStream);
+                }
+                
+
+                {
+                    // We need to write the name first and fix up RVA
+                    {
+                        MINIDUMP_STRING str = new MINIDUMP_STRING()
+                        {
+                            Buffer = dump.SystemInfoServicePack
+                        };
+                        var memPos = stream.Position;
+                        _streamBinaryMapper.WriteObject(stream, typeof(MINIDUMP_STRING), str);
+                        dump.SystemInfoStream.CSDVersionRva = (uint)memPos;
+                    }
+                    WriteDirectoryObject(stream, directory, dump.SystemInfoStream, MINIDUMP_STREAM_TYPE.SystemInfoStream);
+                }
+
+                {
+                    // Write data first, and set the correct RVA
+                    foreach (var memDescriptor in dump.MemoryListStream.MemoryRanges)
+                    {
+                        Debug.Assert(memDescriptor.Memory is MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA); // When writing, we need to know the data
+                        if (memDescriptor.Memory is MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA data)
+                        {
+                            var memPos = stream.Position;
+                            stream.Write(data.MemoryData, 0, data.MemoryData.Length);
+                            data.Rva = (uint)memPos;
+                            data.DataSize = (uint)data.MemoryData.Length;
+                        }
+                    }
+                    WriteDirectoryObject(stream, directory, dump.MemoryListStream, MINIDUMP_STREAM_TYPE.MemoryListStream);
+                }
+
+                {
+                    // We need to write the names first and fix up RVA
+                    foreach (var module in dump.ModuleListStream.Modules)
+                    {
+                        MINIDUMP_STRING str = new MINIDUMP_STRING()
+                        {
+                            Buffer = module.Name
+                        };
+                        var memPos = stream.Position;
+                        _streamBinaryMapper.WriteObject(stream, typeof(MINIDUMP_STRING), str);
+                        module.ModuleNameRva = (uint)memPos;
+                    }
+                    WriteDirectoryObject(stream, directory, dump.ModuleListStream, MINIDUMP_STREAM_TYPE.ModuleListStream);
+                }
+
+                Debug.Assert(directory.Count == dump.Header.NumberOfStreams);
+                stream.Position = dump.Header.StreamDirectoryRva;
+                _streamBinaryMapper.WriteArray(stream, dump.Header.NumberOfStreams, typeof(MINIDUMP_DIRECTORY), directory.ToArray());
+            }
+
+
+        }
+
     }
 }

--- a/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_EXCEPTION.cs
+++ b/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_EXCEPTION.cs
@@ -15,7 +15,7 @@ namespace BinaryMapper.Windows.Minidump.Structures
         public ULONG64 ExceptionAddress;
         public ULONG32 NumberParameters;
         public ULONG32 __unusedAlignment;
-        [ArraySize(nameof(NumberParameters))]
+        [ArraySize(15)]
         public ULONG64[] ExceptionInformation;
     }
 

--- a/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_EXCEPTION_STREAM.cs
+++ b/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_EXCEPTION_STREAM.cs
@@ -1,4 +1,5 @@
-﻿using ULONG32 = System.UInt32;
+﻿using System;
+using ULONG32 = System.UInt32;
 
 namespace BinaryMapper.Windows.Minidump.Structures
 {

--- a/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_HEADER.cs
+++ b/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_HEADER.cs
@@ -30,11 +30,13 @@ namespace BinaryMapper.Windows.Minidump.Structures
         /// <summary>
         /// The number of streams in the minidump directory.
         /// </summary>
+        [FixupAttribute]
         public ULONG32 NumberOfStreams;
         /// <summary>
         /// The base RVA of the minidump directory. The directory is an array of
         /// <see cref="MINIDUMP_DIRECTORY"/> structures.
         /// </summary>
+        [FixupAttribute]
         public RVA StreamDirectoryRva;
         /// <summary>
         /// The checksum for the minidump file. This member can be zero.
@@ -53,6 +55,7 @@ namespace BinaryMapper.Windows.Minidump.Structures
         public ushort VersionMarshaled => Version.LowWord();
     }
 
+    [Flags]
     public enum MINIDUMP_TYPE : ULONG64
     {
         MiniDumpNormal = 0x00000000,

--- a/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA.cs
+++ b/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace BinaryMapper.Windows.Minidump.Structures
 {
-    internal class MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA : MINIDUMP_LOCATION_DESCRIPTOR
+    public class MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA : MINIDUMP_LOCATION_DESCRIPTOR
     {
         /// <summary>
         /// The data stored in this location.

--- a/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA.cs
+++ b/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BinaryMapper.Windows.Minidump.Structures
+{
+    internal class MINIDUMP_LOCATION_DESCRIPTOR_WITH_DATA : MINIDUMP_LOCATION_DESCRIPTOR
+    {
+        /// <summary>
+        /// The data stored in this location.
+        /// </summary>
+        [NonSerialized]
+        public byte[] MemoryData;
+    }
+}

--- a/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_MODULE.cs
+++ b/src/BinaryMapper.Windows.Minidump/Structures/MINIDUMP_MODULE.cs
@@ -63,6 +63,7 @@ namespace BinaryMapper.Windows.Minidump.Structures
         /// <summary>
         /// The name of the module
         /// </summary>
-        public string Name { get; internal set;}
+        [NonSerialized]
+        public string Name;
     }
 }


### PR DESCRIPTION
With this, you can do

```
            var readStream = new System.IO.FileStream("P:/x64_2024-07-24_12-00-08.mdmp", FileMode.Open);
            var dump = new BinaryMapper.Windows.Minidump.MinidumpMapper().ReadMinidump(readStream);

            {
                using (var writeStream = new System.IO.FileStream("P:/x64_2024-07-24_12-00-08_new.mdmp", FileMode.Create))
                {
                    new BinaryMapper.Windows.Minidump.MinidumpMapper().WriteMinidump(writeStream, dump);
                }
            }
```
And it will work in WinDbg
![2024-07-29_18-26-23](https://github.com/user-attachments/assets/ba1382db-cc88-4f3f-8482-36d2daa06433)

This already includes my other PR's.
I expect this will have review issues so I will fix it up once the other PR's are merged.
